### PR TITLE
Add support for setting primus OpenGL implementations

### DIFF
--- a/opengl.eselect
+++ b/opengl.eselect
@@ -21,10 +21,14 @@ EBUILD_VERSION="1.3.3"
 
 # Our data
 MAIN_ENV_FILE="${EROOT}/etc/env.d/03opengl"
+PRIMUS_DISPLAY_ENV_FILE="${EROOT}/etc/env.d/03primus-display"
+PRIMUS_RENDER_ENV_FILE="${EROOT}/etc/env.d/03primus-render"
 XORGD_FILE="${EROOT}/etc/X11/xorg.conf.d/20-opengl.conf"
 PREFIX="${EROOT}/usr"
 DST_PREFIX="${EROOT}/usr"
 unset IGNORE_ERROR
+unset PRIMUS_DISPLAY
+unset PRIMUS_RENDER
 
 
 # Search for symlinks to GL implementation (stdout)
@@ -119,6 +123,20 @@ write_xorg_confd() {
 	echo 'EndSection'
 }
 
+# Remove env file: primus display implentation override; from /etc/env.d/
+remove_primus_display_conf_files() {
+	if [[ -f ${PRIMUS_DISPLAY_ENV_FILE} ]] ; then
+		rm -f "${PRIMUS_DISPLAY_ENV_FILE}" || die -q "Failed to remove ${PRIMUS_DISPLAY_ENV_FILE}"
+	fi
+}
+
+# Remove env file: primus renderer implentation override; from /etc/env.d/
+remove_primus_render_conf_files() {
+	if [[ -f ${PRIMUS_RENDER_ENV_FILE} ]] ; then
+		rm -f "${PRIMUS_RENDER_ENV_FILE}" || die -q "Failed to remove ${PRIMUS_RENDER_ENV_FILE}"
+	fi
+}
+
 # Remove env file: linker paths override; from /etc/env.d/
 # Remove conf file: xorg module search paths override; from /etc/X11/xorg.conf.d
 remove_gl_conf_files() {
@@ -202,39 +220,50 @@ set_new_implementation() {
 
 	check_current_implementation ${gl_implementation}
 
-	echo -n "Switching to ${gl_implementation} OpenGL interface..."
-	remove_gl_conf_files
+	if [[ -n ${PRIMUS_DISPLAY} ]] ; then
+		echo -n "Switching to ${gl_implementation} Primus Display implentation..."
+		remove_primus_display_conf_files
+		store_config ${PRIMUS_DISPLAY_ENV_FILE} PRIMUS_libGLd /usr/\$LIB/opengl/"${gl_implementation}"/lib/libGL.so.1
+	elif [[ -n ${PRIMUS_RENDER} ]] ; then
+		echo -n "Switching to ${gl_implementation} Primus Renderer implentation..."
+		remove_primus_render_conf_files
+		store_config ${PRIMUS_RENDER_ENV_FILE} PRIMUS_libGLr /usr/\$LIB/opengl/"${gl_implementation}"/lib/libGL.so.1
+	else
 
-	# Iterate over main lib directories (/usr/lib{32,64}/)
-	for lib_dir in $(list_libdirs); do
-		[[ ${ROOT} != / ]] && lib_dir=${lib_dir#${EROOT}}
+		echo -n "Switching to ${gl_implementation} OpenGL interface..."
+		remove_gl_conf_files
 
-		# Make sure we have a valid /usr/lib{32,64}/opengl/lib directory
-		# Make sure lib directory is not a symlink (e.g. /usr/lib -> /usr/lib64)
-		[[ -d ${PREFIX}/${lib_dir}/opengl && ! -h ${PREFIX}/${lib_dir} ]] || continue
+		# Iterate over main lib directories (/usr/lib{32,64}/)
+		for lib_dir in $(list_libdirs); do
+			[[ ${ROOT} != / ]] && lib_dir=${lib_dir#${EROOT}}
 
-		# ... add additional X11 xorg global module & GL extension paths too ...
-		if [[ -d ${PREFIX}/${lib_dir}/xorg/${gl_implementation}/extensions ]]; then
-			xorgmodpath+=(
-				"${PREFIX#${ROOT}}/${lib_dir}/xorg/${gl_implementation}"
-			)
-		fi
-		if [[ -d "${PREFIX}/${lib_dir}/xorg/modules" ]]; then
-			xorgmodpath+=(
-				"${PREFIX#${ROOT}}/${lib_dir}/xorg/modules"
-			)
-		fi
+			# Make sure we have a valid /usr/lib{32,64}/opengl/lib directory
+			# Make sure lib directory is not a symlink (e.g. /usr/lib -> /usr/lib64)
+			[[ -d ${PREFIX}/${lib_dir}/opengl && ! -h ${PREFIX}/${lib_dir} ]] || continue
+
+			# ... add additional X11 xorg global module & GL extension paths too ...
+			if [[ -d ${PREFIX}/${lib_dir}/xorg/${gl_implementation}/extensions ]]; then
+				xorgmodpath+=(
+					"${PREFIX#${ROOT}}/${lib_dir}/xorg/${gl_implementation}"
+				)
+			fi
+			if [[ -d "${PREFIX}/${lib_dir}/xorg/modules" ]]; then
+				xorgmodpath+=(
+					"${PREFIX#${ROOT}}/${lib_dir}/xorg/modules"
+				)
+			fi
 		
-		if [[ -d "${PREFIX}/${lib_dir}/opengl/${gl_implementation}" ]]; then
-			cleanup_previous_lib_symlinks "${lib_dir}"
-			create_lib_symlinks "${lib_dir}" "${gl_implementation}"
-		fi
-	done
+			if [[ -d "${PREFIX}/${lib_dir}/opengl/${gl_implementation}" ]]; then
+				cleanup_previous_lib_symlinks "${lib_dir}"
+				create_lib_symlinks "${lib_dir}" "${gl_implementation}"
+			fi
+		done
 	
-	store_config ${MAIN_ENV_FILE} OPENGL_PROFILE "${gl_implementation}"
+		store_config ${MAIN_ENV_FILE} OPENGL_PROFILE "${gl_implementation}"
 
-	mkdir -p $(dirname "${XORGD_FILE}") || die
-	write_xorg_confd "${xorgmodpath[@]}" >"${XORGD_FILE}"
+		mkdir -p $(dirname "${XORGD_FILE}") || die
+		write_xorg_confd "${xorgmodpath[@]}" >"${XORGD_FILE}"
+	fi
 
 	do_action env update &> /dev/null
 
@@ -335,6 +364,8 @@ describe_set_parameters() {
 
 describe_set_options() {
 	echo "<target> : The profile to activate"
+	echo "--primus-display : Set profile for Primus display"
+	echo "--primus-renderer : Set profile for Primus renderer"
 	echo "--use-old : Reload existing implementation (if one is currently set)"
 	echo "--prefix=<val> :  Set prefix (default: /usr)"
 	echo "--ignore-error : Ignore missing files / invalid symlinks when setting a new implementation"
@@ -351,6 +382,12 @@ do_set() {
 		opt=$1
 		shift
 		case ${opt} in
+			--primus-display)
+				PRIMUS_DISPLAY=true
+			;;
+			--primus-renderer)
+				PRIMUS_RENDER=true
+			;;
 			--use-old)
 				if [[ -n ${current} ]] && has ${current} ${available}; then
 					action="old-implementation"
@@ -382,6 +419,9 @@ do_set() {
 			;;
 		esac
 	done
+	if [[ -n ${PRIMUS_DISPLAY} ]] && [[ -n ${PRIMUS_RENDER} ]] ; then
+		die -q "Please specify only one of Primus Display or Renderer"
+	fi
 
 	case ${action} in
 		old-implementation)


### PR DESCRIPTION
Primus requires an OpenGL Display and Renderer
implementation.  Display will usually be your IGD
(Mesa) libGL but could be glvnd or any other libGL.
Whereas typically renderer will be nvidia's libGL or
some other proprietary implementation.

To use this:

`eselect opengl set --primus-display <target>`

or

`eselect opengl set --primus-renderer <target>`